### PR TITLE
v0.19.0

### DIFF
--- a/docs/explanatory/Circuit Permutations.ipynb
+++ b/docs/explanatory/Circuit Permutations.ipynb
@@ -76,20 +76,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "parts_client = SysML2Client()\n",
+    "circuit_client = SysML2Client()\n",
     "\n",
-    "simple_parts_file = Path(pm.__file__).parent / \"../../tests/fixtures/Circuit Builder.json\"\n",
+    "circuit_file = Path(pm.__file__).parent / \"../../tests/fixtures/Circuit Builder.json\"\n",
     "\n",
-    "parts_client._load_from_file(simple_parts_file)\n",
+    "circuit_client._load_from_file(circuit_file)\n",
     "\n",
-    "parts_lpg = SysML2LabeledPropertyGraph()\n",
-    "parts_lpg.model = parts_client.model\n",
+    "circuit_lpg = SysML2LabeledPropertyGraph()\n",
+    "circuit_lpg.model = circuit_client.model\n",
     "\n",
-    "SIMPLE_MODEL = \"Model::Simple Parts Model::\"\n",
+    "circuit_model = circuit_lpg.model\n",
     "\n",
-    "[id_to_parts_name_lookup, parts_name_to_id_lookup] = build_stable_id_lookups(parts_lpg)\n",
+    "[id_to_circuit_name_lookup, circuit_name_to_id_lookup] = build_stable_id_lookups(circuit_lpg)\n",
     "\n",
-    "parts_lpg.model.MAX_MULTIPLICITY = 10"
+    "circuit_lpg.model.MAX_MULTIPLICITY = 10"
    ]
   },
   {
@@ -109,7 +109,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "parts_lpg.model.packages"
+    "circuit_model.packages"
    ]
   },
   {
@@ -119,7 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "parts_lpg.model.ownedElement[\"Circuit Builder\"].ownedElement"
+    "circuit_model.ownedElement[\"Circuit Builder\"].ownedElement"
    ]
   },
   {
@@ -129,7 +129,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "circuit_def = parts_lpg.model.ownedElement[\"Circuit Builder\"].ownedElement[\"Circuit\"]"
+    "circuit_def = circuit_model.ownedElement[\"Circuit Builder\"].ownedElement[\"Circuit\"]"
    ]
   },
   {
@@ -165,439 +165,194 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1d57f5e6-dffc-4484-8650-f6ea44b8b34c",
+   "id": "5243309a-a48b-4b27-b387-d4196ab09006",
    "metadata": {},
    "outputs": [],
    "source": [
-    "id_to_parts_name_lookup[circuit_def.ownedMember[\"Circuit Diode\"]._id]"
+    "circuit_def.ownedMember[7].name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de48c4c1-0e9a-4f82-a6c8-713d8fdf03d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "circuit_def.ownedMember[7].multiplicity.lowerBound"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a9982cf-6460-4b72-836e-ffd7cb23ea6c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "circuit_def.ownedMember[7].multiplicity.upperBound"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "51c07d8b-26e8-475e-8a36-935226a33db8",
+   "id": "94ea2e9f-f4af-4e97-9e5e-713f3833c12a",
    "metadata": {},
    "source": [
-    "#### Feature types for sequences\n",
+    "## Generate M0 instances from the M1 model\n",
     "\n",
-    "We can also inspect the types of each of the features (or classifier themselves) to see what will be placed into each step of the sequence.\n",
-    "\n",
-    "In the below, what we mean to say is that for a given position, the atom in that place will also appear in the 1-tail of the given type. For example, the type that corresponds to the Power User: Part::Power In: Port in the second position, which is a Part, will have all atoms in the 1-tail of Part's sequences. "
+    "Use the M1 model to start creating a series of instances to represent the circuits that should be analyzed."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd25238b-448b-4ec1-8c1b-dc664c62997a",
+   "id": "70a09d8f-af2a-4ecf-af78-78a7439b885f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "feature_templates_with_ids = [[item for item in seq] for seq in build_sequence_templates(parts_lpg)\n",
-    "                                    if id_to_parts_name_lookup[seq[0]].startswith(\"Model::Circuit Builder\")]\n",
-    "feature_templates_with_names = [[id_to_parts_name_lookup[item] for item in seq] for seq in build_sequence_templates(parts_lpg)\n",
-    "                                    if id_to_parts_name_lookup[seq[0]].startswith(\"Model::Circuit Builder\")]\n",
-    "feature_templates_with_names"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "110b7ca4-4004-4eaf-a46e-7608328f7e33",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "[\n",
-    "    [\n",
-    "        [id_to_parts_name_lookup[typ] for typ in get_types_for_feature(parts_lpg, parts_lpg.model.elements[item])]\n",
-    "    for item in seq\n",
-    "    ]\n",
-    "for seq in feature_templates_with_ids\n",
+    "m0_interpretations = [\n",
+    "    random_generator_playbook(\n",
+    "        lpg=circuit_lpg,\n",
+    "        name_hints={},\n",
+    "        filtered_feat_packages=[circuit_lpg.model.ownedElement[\"Circuit Builder\"]],\n",
+    "        phase_limit=10\n",
+    "    ) for run in range(0,100)\n",
     "]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adba109a-bb51-4fd6-9947-b43cbeda220b",
+   "id": "51c29ad1-b744-4026-9fee-416e1c2754b8",
    "metadata": {},
    "outputs": [],
    "source": [
-    "expr_templates_with_ids = [[item for item in seq] for seq in build_expression_sequence_templates(parts_lpg)\n",
-    "                                    if id_to_parts_name_lookup[seq[0]].startswith(\"Model::Circuit Builder\")]\n",
-    "expr_templates_with_names = [[id_to_parts_name_lookup[item] for item in seq] for seq in build_expression_sequence_templates(parts_lpg)\n",
-    "                                    if id_to_parts_name_lookup[seq[0]].startswith(\"Model::Circuit Builder\")]\n",
-    "expr_templates_with_names"
+    "pprint_interpretation(m0_interpretations[0], circuit_model, False)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "62b0b8b4-1ccd-44fc-9485-c3e6b65fed9d",
+   "id": "e0d3308f-053c-4c28-8d09-3c681b48c941",
    "metadata": {},
    "source": [
-    "#### Exploring Connections and Ends\n",
+    "## Filter M0 Instances for Reasonable Circuits\n",
     "\n",
-    "An important kind of feature is the feature that is typed by a Connection, which has two ends."
+    "Until we get more sophisticated and can interpret constraints, the initial approach is to filter out solutions with unanalyzable layouts or trim the layouts to something more tractable."
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "28e665b2-1488-448e-b4ca-a027d4b57f19",
+   "cell_type": "markdown",
+   "id": "fa01e6bf-8afc-4182-b5b4-dca690f03ded",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "connection_usage = [usage for usage in parts_lpg.model.ownedElement[\"Circuit Builder\"].ownedElement[\"Circuit\"].ownedElement\n",
-    "                        if usage._metatype == \"ConnectionUsage\"][0]\n",
-    "connection_usage"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bd5ef697-66c5-4dc4-a86f-4c3acbbe59fb",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ptg = parts_lpg.get_projection(\"Part Typing\")\n",
-    "scg = parts_lpg.get_projection(\"Part Definition\")\n",
-    "ssg = parts_lpg.get_projection(\"Redefinition and Subsetting\")\n",
-    "bdg = parts_lpg.get_projection(projection=\"Expanded Banded\", packages=[parts_lpg.model.ownedElement[\"Occurrences\"]])\n",
-    "bdg_all = parts_lpg.get_projection(projection=\"Expanded Banded\")\n",
+    "### Connector End Checks\n",
     "\n",
-    "full_multiplicities = random_generator_phase_1_multiplicities(parts_lpg, ptg, scg)"
+    "Look at the ends of the three main kinds of connectors."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f98cc909-2ac3-4de1-a8e0-005ae96f88ea",
+   "id": "a310351a-4830-4598-aff9-8177170deec1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "{\n",
-    "    id_to_parts_name_lookup[k]:v\n",
-    "    for k, v in full_multiplicities.items()\n",
-    "}"
+    "n2n = circuit_def.ownedMember[\"Node to Node\"]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4846f0fe-ea1a-4279-8b40-235d72f6a973",
+   "id": "70a0f874-05ea-4643-9162-ea836cc0d31d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "{\n",
-    "    k:v\n",
-    "    for k, v in full_multiplicities.items()\n",
-    "}"
+    "p2p = circuit_def.ownedMember[\"Part to Part\"]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8519a01a-694d-4cd2-a3b8-02da67d1119d",
+   "id": "6a3e9245-8e48-4414-bccc-670dac12aba4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "[id_to_parts_name_lookup[typ_] for typ_ in get_features_typed_by_type(parts_lpg, '81b05f03-a17a-4f51-83a2-06d7f19d5c6d')]"
+    "p2n = circuit_def.ownedMember[\"Part to Node\"]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c4c67be5-9c05-427a-a537-871d2d7761fc",
+   "id": "96c413fb-b3ca-4bd6-9d0d-b129c60141f3",
    "metadata": {},
    "outputs": [],
    "source": [
-    "nx.is_directed_acyclic_graph(ptg)"
+    "circuit_def.ownedMember[\"Part to Part\"].endFeature[0]._id"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e91a8a33-b7c1-4a48-8bc8-8f75e2cb6582",
+   "id": "0fc24db1-db38-4c1d-b215-c031535df452",
    "metadata": {},
    "outputs": [],
    "source": [
-    "nx.is_directed_acyclic_graph(scg)"
+    "m0_interpretations[10][p2n.endFeature[0]._id]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f58fcf2-83b5-4868-b6c1-fa7b5d125e52",
+   "id": "39caaab1-6d91-4a6b-a166-e70e22f7e075",
    "metadata": {},
    "outputs": [],
    "source": [
-    "nx.is_directed_acyclic_graph(ssg)"
+    "m0_interpretations[10][p2n.endFeature[1]._id]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c7a121c-029a-43e2-b0ce-fef09be41725",
+   "id": "b24b8b54-4d59-4a27-bc29-cbfefd5d01f0",
    "metadata": {},
    "outputs": [],
    "source": [
-    "nx.is_directed_acyclic_graph(bdg)"
+    "m0_interpretations[10][p2p.endFeature[0]._id]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bf774694-0ed4-4372-a632-b0c14e3b2ed1",
+   "id": "171cb461-cfe3-42da-aea0-423c9f336321",
    "metadata": {},
    "outputs": [],
    "source": [
-    "len(ssg.nodes)"
+    "m0_interpretations[10][p2p.endFeature[1]._id]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e3c894d0-1856-464c-9f98-979e592b4074",
+   "id": "c508c95d-60a1-4852-92f5-9417509e4a7f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "len(ssg.edges)"
+    "m0_interpretations[10][n2n.endFeature[0]._id]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eeeaaf38-92c1-4b5a-9b68-b04cceca2ffb",
+   "id": "d60b2b37-bef6-4071-b4ba-19312d6488b7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "[id_to_parts_name_lookup[node] for listing in nx.simple_cycles(ssg) for node in listing]"
+    "m0_interpretations[10][n2n.endFeature[1]._id]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57c22fef-d14b-4049-b774-231dee403d32",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "[\n",
-    "    id_to_parts_name_lookup[node]\n",
-    "    for node in bdg_all.nodes\n",
-    "    if bdg_all.out_degree(node) < 1\n",
-    "]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d5adb9f3-d1d7-463c-a05d-c1eb7a1a40ac",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "[[id_to_parts_name_lookup[node] for node in listing] for listing in nx.simple_cycles(bdg_all)]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f69caa26-5365-4c89-a9ec-2360bf07a8b6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "item_def_id = parts_name_to_id_lookup[\"Model::Items::Item <<ItemDefinition>>\"]\n",
-    "done_item_id = parts_name_to_id_lookup[\"Model::Items::Item::done: Item <<ItemUsage>>\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c10beecb-0b76-45cc-8a85-a79182c86d0b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "list(nx.all_simple_paths(\n",
-    "    bdg_all,\n",
-    "    source=item_def_id,\n",
-    "    target=done_item_id,\n",
-    "))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "879ec85d-4ef6-42ab-a219-f5195a8bf981",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "[id_to_parts_name_lookup[item] for item in bdg_all.predecessors(item_def_id)]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2f16e420-1009-4948-82fa-81dc00b3e0dd",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cycle_check = [node for listing in nx.simple_cycles(ssg) for node in listing]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b4165f3d-9e2d-4e46-b756-d52433a58264",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "list(ssg.predecessors(cycle_check[1]))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a4f053bb-8cd8-40a4-973f-e075ef8f29c9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "[parts_lpg.model.elements[item] for item in parts_lpg.get_projection(\"Generalization\")]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "475a133f-5e81-419f-a1a7-4c68033dff33",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "m0_interpretation = random_generator_playbook(\n",
-    "    lpg=parts_lpg,\n",
-    "    name_hints={},\n",
-    "    filtered_feat_packages=[parts_lpg.model.ownedElement[\"Circuit Builder\"]],\n",
-    "    phase_limit=10\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "42cc1aad-21a3-4518-97ca-14d54451c177",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "parts_lpg.model.ownedElement[\"Circuit Builder\"].ownedElement[\"Circuit Connection\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fdddca37-3b9a-4ba7-852a-91c08cf3bec7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "parts_lpg.model.ownedElement[\"Circuit Builder\"].ownedElement[\"Circuit\"].ownedMember[\"Component\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1a00a024-b58e-4f91-8427-00f5b1d0bb55",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "m0_interpretation[parts_lpg.model.ownedElement[\"Circuit Builder\"].ownedElement[\"Circuit Connection\"]._id]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8873ae60-778e-4f08-8261-3c01ae3a3591",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "m0_interpretation[parts_lpg.model.ownedElement[\"Circuit Builder\"].ownedElement[\"Circuit\"].ownedMember[\"Circuit Resistor\"]._id]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "132ea127-29c7-41e2-b79a-25850053e1f0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "m0_interpretation[parts_lpg.model.ownedElement[\"Circuit Builder\"].ownedElement[\"Circuit\"].ownedMember[\"Circuit Diode\"]._id]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "385a1f5b-9d27-4cf2-90dd-039fd33fefa5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "m0_interpretation[parts_lpg.model.ownedElement[\"Circuit Builder\"].ownedElement[\"Circuit\"].ownedMember[\"Motive Force\"]._id]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5d6803c9-b364-4e9f-8bb6-e1ed4c242e81",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "m0_interpretation[parts_lpg.model.ownedElement[\"Circuit Builder\"].ownedElement[\"EMF\"]._id]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5e7fd7fe-6149-4569-ac29-8fc05e118c78",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dict(nx.bfs_successors(parts_lpg.get_projection(\"Generalization\"), '9b93e6a8-d44e-4e17-a859-9cdedf60c144'))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6186a51f-380c-43dd-897f-5ce5b1d7a668",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "parts_lpg.model.ownedElement[\"Circuit Builder\"].ownedElement[\"Circuit\"].ownedMember[\"Circuit Diode\"]._id"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "97187dbd-e417-4c5a-897b-4249befa504d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "m0_interpretation[parts_lpg.model.ownedElement[\"Circuit Builder\"].ownedElement[\"Circuit\"].ownedMember[\"Component\"]._id]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ce02435e-e884-4827-9758-9b223d525718",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "12fe3f73-8db5-47c6-ab02-afe4b1483752",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pprint_interpretation(m0_interpretation, parts_lpg.model)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3a4df784-a091-44a6-81c6-e0041d176d74",
+   "id": "96aa0e0e-7417-405e-8b93-373d00290fb2",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/docs/explanatory/Circuit Permutations.ipynb
+++ b/docs/explanatory/Circuit Permutations.ipynb
@@ -350,12 +350,119 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "f89bbedc-46ed-4d92-aee0-56a6a6cfd029",
+   "metadata": {},
+   "source": [
+    "# OpenMDAO\n",
+    "> Based on OpenMDAO's [nonlinear circuit analysis example](https://openmdao.org/newdocs/versions/latest/examples/circuit_analysis_examples.html)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96aa0e0e-7417-405e-8b93-373d00290fb2",
+   "id": "11e56f12-e04d-4371-99c5-ea14fb0833de",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "import openmdao.api as om\n",
+    "from openmdao.test_suite.test_examples.test_circuit_analysis import Diode, Node, Resistor"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ecb3de5-e6cb-4c9a-a7e9-a35375f27d97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Circuit(om.Group):\n",
+    "\n",
+    "    def setup(self):\n",
+    "        self.add_subsystem('n1', Node(n_in=1, n_out=2), promotes_inputs=[('I_in:0', 'I_in')])\n",
+    "        self.add_subsystem('n2', Node())  # leaving defaults\n",
+    "\n",
+    "        self.add_subsystem('R1', Resistor(R=100.), promotes_inputs=[('V_out', 'Vg')])\n",
+    "        self.add_subsystem('R2', Resistor(R=10000.))\n",
+    "        self.add_subsystem('D1', Diode(), promotes_inputs=[('V_out', 'Vg')])\n",
+    "\n",
+    "        self.connect('n1.V', ['R1.V_in', 'R2.V_in'])\n",
+    "        self.connect('R1.I', 'n1.I_out:0')\n",
+    "        self.connect('R2.I', 'n1.I_out:1')\n",
+    "\n",
+    "        self.connect('n2.V', ['R2.V_out', 'D1.V_in'])\n",
+    "        self.connect('R2.I', 'n2.I_in:0')\n",
+    "        self.connect('D1.I', 'n2.I_out:0')\n",
+    "\n",
+    "        self.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)\n",
+    "        self.nonlinear_solver.options['iprint'] = 2\n",
+    "        self.nonlinear_solver.options['maxiter'] = 20\n",
+    "        self.linear_solver = om.DirectSolver()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25399825-ccd0-4da1-abc2-98c252a2f48a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = om.Problem()\n",
+    "model = p.model\n",
+    "\n",
+    "model.add_subsystem('ground', om.IndepVarComp('V', 0., units='V'))\n",
+    "model.add_subsystem('source', om.IndepVarComp('I', 0.1, units='A'))\n",
+    "model.add_subsystem('circuit', Circuit())\n",
+    "\n",
+    "model.connect('source.I', 'circuit.I_in')\n",
+    "model.connect('ground.V', 'circuit.Vg')\n",
+    "\n",
+    "p.setup()\n",
+    "\n",
+    "# set some initial guesses\n",
+    "p['circuit.n1.V'] = 12.\n",
+    "p['circuit.n2.V'] = 1.\n",
+    "\n",
+    "p.run_model()\n",
+    "\n",
+    "print(p['circuit.n1.V'])\n",
+    "print(p['circuit.n2.V'])\n",
+    "print(p['circuit.R1.I'])\n",
+    "print(p['circuit.R2.I'])\n",
+    "print(p['circuit.D1.I'])\n",
+    "\n",
+    "# sanity check: should sum to .1 Amps\n",
+    "assert p['circuit.R1.I'] + p['circuit.D1.I'] == 0.1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19644686-19ea-47e3-b7c5-1157cca71cbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "elements = circuit_model.elements\n",
+    "sequences = m0_interpretations[20]\n",
+    "\n",
+    "id_ = \"99db05a8-32cd-4676-a936-0bc13bb6ec29\"\n",
+    "id_ = \"2ac62b51-dabf-4516-b56e-84e77ef3a67a\"\n",
+    "id_ = \"06fb7cf9-09e0-43c0-84a8-a5ac334b0b51\"\n",
+    "id_ = \"8dbe719d-b4e1-47b6-a40d-4c5fcfd30eba\"\n",
+    "id_ = \"35cb79bd-c6fa-400b-a37a-3ab28793d996\"\n",
+    "\n",
+    "elements[id_].owner.ownedElement, sequences[id_], sequences[\"11e7ca81-539a-414e-b59b-96c5c34d7aa4\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38f265ac-f7cd-4c7e-acb8-190c306dfd13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m0_interpretations[0]"
+   ]
   }
  ],
  "metadata": {

--- a/src/pymbe/api.py
+++ b/src/pymbe/api.py
@@ -1,3 +1,10 @@
+from .model import Instance, Model
+from .widget.client import APIClientWidget
+from .widget.containment import ContainmentTree
+from .widget.diagram import M0Viewer, M1Viewer
+from .widget.inspector import ElementInspector
+from .widget.ui import UI
+
 __all__ = (
     "ContainmentTree",
     "ElementInspector",
@@ -5,14 +12,6 @@ __all__ = (
     "M0Viewer",
     "M1Viewer",
     "Model",
-    "SysML2ClientWidget",
+    "APIClientWidget",
     "UI",
 )
-
-
-from .model import Instance, Model
-from .widget.client import SysML2ClientWidget
-from .widget.containment import ContainmentTree
-from .widget.diagram import M0Viewer, M1Viewer
-from .widget.inspector import ElementInspector
-from .widget.ui import UI

--- a/src/pymbe/client.py
+++ b/src/pymbe/client.py
@@ -123,9 +123,7 @@ class SysML2Client(trt.HasTraits):
         elements = elements or []
         self.model = Model.load(
             elements=elements,
-            name=f"""{
-                self.projects[self.selected_project]["name"]
-            } ({self.host})""",
+            name=self.projects[self.selected_project]["name"],
             source=self.elements_url,
         )
         for element in self.model.elements.values():

--- a/src/pymbe/graph/lpg.py
+++ b/src/pymbe/graph/lpg.py
@@ -226,7 +226,7 @@ class SysML2LabeledPropertyGraph(trt.HasTraits):  # pylint: disable=too-many-ins
             included_packages=tuple(sorted(included_packages)),
         ).copy()
 
-    @lru_cache(maxsize=128)
+    @lru_cache(maxsize=1024)
     def _adapt(
         self,
         excluded_node_types: ty.Union[list, set, tuple] = None,

--- a/src/pymbe/interpretation/interp_playbooks.py
+++ b/src/pymbe/interpretation/interp_playbooks.py
@@ -283,7 +283,7 @@ def random_generator_playbook_phase_3(
         # skip if the feature is abstract or its owning type is
         last_item = model.elements[feature_sequence[-1]]
         if last_item.isAbstract:
-            print(f"Skipped sequence ending in {last_item}")
+            #print(f"Skipped sequence ending in {last_item}")
             continue
 
         new_sequences = []
@@ -409,7 +409,7 @@ def random_generator_playbook_phase_3_new_instances(
         # skip if the feature is abstract or its owning type is
         last_item = model.elements[feature_sequence[-1]]
         if last_item.isAbstract or last_item.owner.isAbstract:
-            print(f"Skipped sequnce ending in {last_item}")
+            #print(f"Skipped sequnce ending in {last_item}")
             continue
 
         new_sequences = []
@@ -618,15 +618,20 @@ def random_generator_playbook_phase_5(
             min_side = min(len(source_sequences), len(target_sequences))
             max_side = max(len(source_sequences), len(target_sequences))
 
+            if min_side == 0:
+                instances_dict[connector_ends[0]._id] = []
+                instances_dict[connector_ends[1]._id] = []
+                continue # nothing to connect
+
             try:
                 if len(source_sequences) <= len(target_sequences):
                     source_indices = list(range(0, min_side))
-                    other_steps = sample(range(0, min_side), (max_side - min_side))
+                    other_steps = [randint(0, min_side - 1) for _ in range(0, (max_side - min_side))]
                     source_indices.extend(other_steps)
                     target_indices = sample(range(0, max_side), max_side)
                 else:
                     source_indices = sample(range(0, max_side), max_side)
-                    other_steps = sample(range(0, min_side), (max_side - min_side))
+                    other_steps = [randint(0, min_side - 1) for _ in range(0, (max_side - min_side))]
                     target_indices = list(range(0, min_side))
                     target_indices.extend(other_steps)
             except ValueError as exc:

--- a/src/pymbe/interpretation/interp_playbooks.py
+++ b/src/pymbe/interpretation/interp_playbooks.py
@@ -46,6 +46,8 @@ TYPES_FOR_ROLL_UP_MULTIPLICITY = (
     "StateDefinition",
 )
 
+TYPES_FOR_CONNECTOR_INSTANCES = ("ConnectionUsage", "InterfaceUsage", "SuccessionUsage")
+
 
 def random_generator_playbook(
     lpg: SysML2LabeledPropertyGraph,
@@ -283,7 +285,7 @@ def random_generator_playbook_phase_3(
         # skip if the feature is abstract or its owning type is
         last_item = model.elements[feature_sequence[-1]]
         if last_item.isAbstract:
-            #print(f"Skipped sequence ending in {last_item}")
+            # print(f"Skipped sequence ending in {last_item}")
             continue
 
         new_sequences = []
@@ -409,7 +411,7 @@ def random_generator_playbook_phase_3_new_instances(
         # skip if the feature is abstract or its owning type is
         last_item = model.elements[feature_sequence[-1]]
         if last_item.isAbstract or last_item.owner.isAbstract:
-            #print(f"Skipped sequnce ending in {last_item}")
+            # print(f"Skipped sequnce ending in {last_item}")
             continue
 
         new_sequences = []
@@ -578,97 +580,83 @@ def random_generator_playbook_phase_5(
     """
     Generate instances for connector usages and their specializations and randomly
     connect ends to legal sources and targets
+
     :param lpg: Active SysML graph
     :param cug: A connector usage graph projection to see where their source/targets are linked
     :param instances_dict: Working dictionary of interpreted sequences for the model
+
     :return: None - side effect is addition of new instances to the instances dictionary
     """
-
+    elements = lpg.model.elements
     # Generate sequences for connection and interface ends
-    for node_id in list(cug.nodes):
-        node = lpg.model.elements[node_id]
-        if node._metatype in ("ConnectionUsage", "InterfaceUsage", "SuccessionUsage"):
+    for connector_id in cug.nodes:
+        connector = elements[connector_id]
+        if connector._metatype not in TYPES_FOR_CONNECTOR_INSTANCES:
+            continue
 
-            connector_ends = node.connectorEnd
+        connector_ends = connector.connectorEnd
+        if len(connector_ends) != 2:
+            raise NotImplementedError(
+                f"Cannot process connector {connector} because it"
+                f" it has {len(connector_ends) or 'no'} connector end(s)"
+            )
 
-            connector_id = node._id
+        source, *other_sources = connector.source
+        target, *other_targets = connector.target
+        if other_sources or other_targets:
+            raise NotImplementedError(
+                f"Cannot process connector {connector} because it"
+                " has multiple sources and/or targets"
+            )
 
-            source_feat_id = node.source[0].chainingFeature[-1]._id
-            target_feat_id = node.target[0].chainingFeature[-1]._id
+        try:
+            source_sequences = instances_dict[source.chainingFeature[-1]._id]
+        except KeyError as exc:
+            raise KeyError(f"Cannot find chaining feature sequences for {source}!") from exc
 
-            try:
-                source_sequences = instances_dict[source_feat_id]
-            except KeyError as exc:
-                raise KeyError(
-                    f"Cannot find {lpg.model.elements[source_feat_id]} in the interpretation!"
-                ) from exc
+        try:
+            target_sequences = instances_dict[target.chainingFeature[-1]._id]
+        except KeyError as exc:
+            raise KeyError(f"Cannot find chaining feature sequences for {target}!") from exc
 
-            try:
-                target_sequences = instances_dict[target_feat_id]
-            except KeyError as exc:
-                raise KeyError(
-                    f"Cannot find {lpg.model.elements[target_feat_id]} in the interpretation!"
-                ) from exc
+        # Get sequence sizes for each side
+        sizes = len(source_sequences), len(target_sequences)
+        min_side, max_side = min(sizes), max(sizes)
 
-            connectors = instances_dict[connector_id]
+        # if one side has no connections, there's nothing to connect
+        if min_side < 1:
+            for connector_end in connector_ends:
+                instances_dict[connector_end._id] = []
+            continue
 
-            extended_source_sequences = []
-            extended_target_sequences = []
+        try:
+            indeces = list(range(min_side)) + [
+                randint(0, min_side - 1) for _ in range(max_side - min_side)
+            ]
+            if len(source_sequences) <= len(target_sequences):
+                connector_ends_indeces = indeces, sample(range(max_side), max_side)
+            else:
+                connector_ends_indeces = sample(range(max_side), max_side), indeces
+        except ValueError as exc:
+            raise ValueError(
+                "Sample larger than population or is negative. Sizes are:"
+                f" {min_side} and {max_side}."
+            ) from exc
 
-            min_side = min(len(source_sequences), len(target_sequences))
-            max_side = max(len(source_sequences), len(target_sequences))
-
-            if min_side == 0:
-                instances_dict[connector_ends[0]._id] = []
-                instances_dict[connector_ends[1]._id] = []
-                continue # nothing to connect
-
-            try:
-                if len(source_sequences) <= len(target_sequences):
-                    source_indices = list(range(0, min_side))
-                    other_steps = [randint(0, min_side - 1) for _ in range(0, (max_side - min_side))]
-                    source_indices.extend(other_steps)
-                    target_indices = sample(range(0, max_side), max_side)
-                else:
-                    source_indices = sample(range(0, max_side), max_side)
-                    other_steps = [randint(0, min_side - 1) for _ in range(0, (max_side - min_side))]
-                    target_indices = list(range(0, min_side))
-                    target_indices.extend(other_steps)
-            except ValueError as exc:
-                raise ValueError(
-                    f"Sample larger than population or is negative. Min_side size is {min_side} "
-                    f"and max_side size is {max_side}."
-                ) from exc
-
-            # taking over indx to wrap around
-            indx = 0
-
-            for seq in connectors:
-                new_source_seq = []
-                new_target_seq = []
-
-                for item in seq:
-                    new_source_seq.append(item)
-                    new_target_seq.append(item)
-
-                for jndx, item in enumerate(source_sequences[source_indices[indx]]):
-                    if jndx > 0:
-                        new_source_seq.append(item)
-
-                for jndx, item in enumerate(target_sequences[target_indices[indx]]):
-                    if jndx > 0:
-                        new_target_seq.append(item)
-
-                extended_source_sequences.append(new_source_seq)
-                extended_target_sequences.append(new_target_seq)
-
-                if indx >= len(target_indices) - 1:
-                    indx = 0
-                else:
-                    indx = indx + 1
-
-            instances_dict[connector_ends[0]._id] = extended_source_sequences
-            instances_dict[connector_ends[1]._id] = extended_target_sequences
+        connector_ends_sequences = (source_sequences, target_sequences)
+        connector_sequences = instances_dict[connector_id]
+        for connector_end, connector_end_indeces, connector_end_sequences in zip(
+            connector_ends, connector_ends_indeces, connector_ends_sequences
+        ):
+            instances_dict[connector_end._id] = [
+                [
+                    sequence
+                    + connector_end_sequences[
+                        connector_end_indeces[idx % len(connector_end_sequences)]
+                    ][1:]
+                ]
+                for idx, sequence in enumerate(connector_sequences)
+            ]
 
 
 def build_sequence_templates(lpg: SysML2LabeledPropertyGraph) -> List[List[str]]:

--- a/src/pymbe/model.py
+++ b/src/pymbe/model.py
@@ -81,6 +81,7 @@ class Model:  # pylint: disable=too-many-instance-attributes
 
     source: Any = None
 
+    _api: Any = None
     _naming: Naming = Naming.LONG  # The scheme to use for repr'ing the elements
 
     def __post_init__(self):

--- a/src/pymbe/model.py
+++ b/src/pymbe/model.py
@@ -133,6 +133,9 @@ class Model:  # pylint: disable=too-many-instance-attributes
         )
 
     def save_to_file(self, filepath: Union[Path, str], indent: int = 2):
+        if not self.elements:
+            warn("Model has no elements, nothing to save!")
+            return
         if isinstance(filepath, str):
             filepath = Path(filepath)
         if not filepath.name.endswith(".json"):

--- a/src/pymbe/model.py
+++ b/src/pymbe/model.py
@@ -135,6 +135,10 @@ class Model:  # pylint: disable=too-many-instance-attributes
     def save_to_file(self, filepath: Union[Path, str], indent: int = 2):
         if isinstance(filepath, str):
             filepath = Path(filepath)
+        if not filepath.name.endswith(".json"):
+            filepath = filepath.parent / f"{filepath.name}.json"
+        if filepath.exists():
+            warn(f"Overwriting {filepath}")
         filepath.write_text(
             json.dumps(
                 [element._data for element in self.elements.values()],

--- a/src/pymbe/widget/client.py
+++ b/src/pymbe/widget/client.py
@@ -9,11 +9,11 @@ from ..client import APIClient
 from ..model import Model
 from .core import BaseWidget
 
-__all__ = ("APIClientWidget", "SysML2FileLoader")
+__all__ = ("APIClientWidget", "FileLoader")
 
 
 @ipyw.register
-class SysML2FileLoader(FileBox, BaseWidget):
+class FileLoader(FileBox, BaseWidget):
     """A simple UI for loading SysML models from disk."""
 
     closable: bool = trt.Bool(True).tag(sync=True)

--- a/src/pymbe/widget/containment.py
+++ b/src/pymbe/widget/containment.py
@@ -145,7 +145,7 @@ class ContainmentTree(ipyw.VBox, BaseWidget):
 
     def _save_to_disk(self, *_):
         with self.log_out:
-            if not self.model or not self.model.elements:
+            if not self.model:
                 print("No model loaded!")
                 return
             self.model.save_to_file(filepath=Path(".") / self.model.name)

--- a/src/pymbe/widget/containment.py
+++ b/src/pymbe/widget/containment.py
@@ -8,7 +8,7 @@ import traitlets as trt
 from wxyz.lab import DockPop
 
 from ..model import Element, Model
-from .client import SysML2ClientWidget, SysML2FileLoader
+from .client import APIClientWidget, SysML2FileLoader
 from .core import BaseWidget
 
 __all__ = ("ContainmentTree",)
@@ -36,7 +36,7 @@ class ContainmentTree(ipyw.VBox, BaseWidget):
     description: str = trt.Unicode("Containment Tree").tag(sync=True)
     icon_class: str = trt.Unicode("jp-TreeViewIcon").tag(sync=True)
 
-    client: SysML2ClientWidget = trt.Instance(SysML2ClientWidget)
+    api_client: APIClientWidget = trt.Instance(APIClientWidget)
     file_loader: SysML2FileLoader = trt.Instance(SysML2FileLoader, args=())
 
     default_icon: str = trt.Unicode("genderless").tag(sync=True)
@@ -119,14 +119,14 @@ class ContainmentTree(ipyw.VBox, BaseWidget):
         self.save_model.on_click(self._save_to_disk)
 
         for linked_attribute in ("model", "log_out"):
-            for widget in (self.client, self.file_loader):
+            for widget in (self.api_client, self.file_loader):
                 trt.link((self, linked_attribute), (widget, linked_attribute))
 
-    @trt.default("client")
-    def _make_client(self) -> SysML2ClientWidget:
-        client = SysML2ClientWidget(host_url="http://sysml2.intercax.com")
-        client._set_layout()
-        return client
+    @trt.default("api_client")
+    def _make_api_client(self) -> APIClientWidget:
+        api_client = APIClientWidget(host_url="http://sysml2.intercax.com")
+        api_client._set_layout()
+        return api_client
 
     @trt.default("add_widget")
     def _make_add_widget(self) -> ty.Callable:
@@ -152,7 +152,7 @@ class ContainmentTree(ipyw.VBox, BaseWidget):
 
     def _pop_api_client(self, *_):
         with self.log_out:
-            self.add_widget(self.client, mode="split-top")
+            self.add_widget(self.api_client, mode="split-top")
 
     def _pop_log_out(self, *_):
         with self.log_out:

--- a/src/pymbe/widget/containment.py
+++ b/src/pymbe/widget/containment.py
@@ -8,7 +8,7 @@ import traitlets as trt
 from wxyz.lab import DockPop
 
 from ..model import Element, Model
-from .client import APIClientWidget, SysML2FileLoader
+from .client import APIClientWidget, FileLoader
 from .core import BaseWidget
 
 __all__ = ("ContainmentTree",)
@@ -37,7 +37,7 @@ class ContainmentTree(ipyw.VBox, BaseWidget):
     icon_class: str = trt.Unicode("jp-TreeViewIcon").tag(sync=True)
 
     api_client: APIClientWidget = trt.Instance(APIClientWidget)
-    file_loader: SysML2FileLoader = trt.Instance(SysML2FileLoader, args=())
+    file_loader: FileLoader = trt.Instance(FileLoader, args=())
 
     default_icon: str = trt.Unicode("genderless").tag(sync=True)
     indeterminate_icon: str = trt.Unicode("question").tag(sync=True)

--- a/src/pymbe/widget/core.py
+++ b/src/pymbe/widget/core.py
@@ -10,6 +10,7 @@ from ..model import Model
 class BaseWidget(ipyw.DOMWidget):
     """A base widget to enforce standardization with selectors."""
 
+    closable: bool = trt.Bool(False).tag(sync=True)
     description = trt.Unicode("Unnamed Widget").tag(sync=True)
 
     model: Model = trt.Instance(Model, allow_none=True, help="The instance of the SysML model.")

--- a/src/pymbe/widget/ui.py
+++ b/src/pymbe/widget/ui.py
@@ -32,7 +32,7 @@ class UI(DockBox):
         super().__init__(*args, **kwargs)
         self.description = "SysML Model"
 
-        self.tree.client.host_url = host_url
+        self.tree.api_client.host_url = host_url
 
         self.children = [
             self.tree,

--- a/tests/client/test_client_loading.py
+++ b/tests/client/test_client_loading.py
@@ -13,7 +13,7 @@ def can_connect(host: str, port: int = 9000):
     try:
         requests.get(f"{host}:{port}")
         return True
-    except:
+    except:  # pylint: disable=bare-except
         return False
 
 

--- a/tests/client/test_client_loading.py
+++ b/tests/client/test_client_loading.py
@@ -1,7 +1,7 @@
 import pytest
 import requests
 
-from tests.conftest import all_kerbal_names, kerbal_client, kerbal_ids_by_type
+from pymbe.client import APIClient
 
 SYSML_SERVER_URL = "http://sysml2-sst.intercax.com"  # Alternative: sysml2.intercax.com
 
@@ -14,8 +14,8 @@ def can_connect(host: str, port: int = 9000):
         return False
 
 
-def test_client_load_kerbal(kerbal_client):
-    assert len(kerbal_client.model.elements) == 380
+def test_client_load_kerbal(kerbal_model):
+    assert len(kerbal_model.elements) == 380
 
 
 def test_client_load_find_names(all_kerbal_names):
@@ -36,8 +36,8 @@ def test_client_load_find_types(kerbal_ids_by_type):
     not can_connect(host=SYSML_SERVER_URL),
     reason=f"Can't connect to {SYSML_SERVER_URL}",
 )
-def test_remote_connection(kerbal_client):
-    client = kerbal_client
+def test_remote_connection():
+    client = APIClient()
     client.host_url = SYSML_SERVER_URL
 
     assert client.projects
@@ -46,7 +46,6 @@ def test_remote_connection(kerbal_client):
 
     client.selected_project = list(client.projects)[0]
     client.selected_commit = list(client._get_project_commits())[0]
-    client._download_elements()
+    model = client.get_model()
 
-    model = client.model
     assert model.elements

--- a/tests/graph/test_graph_load.py
+++ b/tests/graph/test_graph_load.py
@@ -1,8 +1,6 @@
 import networkx as nx
 import pytest
 
-from tests.conftest import kerbal_ids_by_type, kerbal_lpg, kerbal_model_loaded_client
-
 
 def test_graph_load(kerbal_lpg):
     assert len(kerbal_lpg.nodes) == 152

--- a/tests/graph/test_graph_load.py
+++ b/tests/graph/test_graph_load.py
@@ -9,7 +9,7 @@ def test_graph_load(kerbal_lpg):
     )  # nodes + edges should be all elements from the client
 
 
-@pytest.mark.skip("Need to refactor tests, after 0.19.0 upgrades")
+@pytest.mark.skip("Need to refactor tests, after upgrades")
 def test_graph_projection_part_def_node_filter(kerbal_lpg, kerbal_ids_by_type):
     pdg = kerbal_lpg.get_projection("Part Definition")
 
@@ -25,7 +25,7 @@ def test_graph_projection_part_def_node_filter(kerbal_lpg, kerbal_ids_by_type):
     assert len(pdg.nodes) == len(kerbal_ids_by_type["PartDefinition"]) - 1
 
 
-@pytest.mark.skip("Need to refactor tests, after 0.19.0 upgrades")
+@pytest.mark.skip("Need to refactor tests, after upgrades")
 def test_graph_projection_part_def_components(kerbal_lpg):
     pdg = kerbal_lpg.get_projection("Part Definition")
 

--- a/tests/graph/test_graph_solve.py
+++ b/tests/graph/test_graph_solve.py
@@ -13,7 +13,7 @@ PARTS_LIBRARY = "Model::Kerbal::Parts Library::"
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skip("Need to refactor tests, after 0.19.0 upgrades")
+@pytest.mark.skip("Need to refactor tests, after upgrades")
 def test_basic_kerbal_solve(kerbal_lpg, kerbal_random_stage_5_complete, kerbal_stable_names):
     # check that literal assignments go correctly
 

--- a/tests/interpretation/test_calculation_ordering.py
+++ b/tests/interpretation/test_calculation_ordering.py
@@ -7,7 +7,7 @@ ROCKET_BUILDING = "Model::Kerbal::Rocket Building::"
 PARTS_LIBRARY = "Model::Kerbal::Parts Library::"
 
 
-@pytest.mark.skip("Need to refactor tests, after 0.19.0 upgrades")
+@pytest.mark.skip("Need to refactor tests, after upgrades")
 def test_kerbal_calc_order(kerbal_lpg, kerbal_random_stage_5_complete, kerbal_stable_names):
     # check that the right number of values are created for their features
 

--- a/tests/interpretation/test_graph_orderings.py
+++ b/tests/interpretation/test_graph_orderings.py
@@ -1,7 +1,5 @@
 import networkx as nx
 
-from tests.conftest import kerbal_model_loaded_client
-
 
 def test_part_def_graph_ordering(kerbal_lpg):
 

--- a/tests/interpretation/test_graph_visit_orderings.py
+++ b/tests/interpretation/test_graph_visit_orderings.py
@@ -2,7 +2,7 @@ from pymbe.interpretation.interp_playbooks import (
     build_expression_sequence_templates,
     build_sequence_templates,
 )
-from pymbe.interpretation.results import *
+from pymbe.interpretation.results import pprint_double_id_list
 
 ROCKET_BUILDING = "Model::Kerbal::Rocket Building::"
 PARTS_LIBRARY = "Model::Kerbal::Parts Library::"
@@ -11,15 +11,15 @@ SIMPLE_MODEL = "Model::Simple Parts Model::"
 PARTS_LIBRARY = "Model::Simple Parts Model::Fake Library::"
 
 
-def test_feature_sequence_templates1(kerbal_client, kerbal_lpg, kerbal_stable_names):
+def test_feature_sequence_templates1(kerbal_lpg, kerbal_stable_names):
     *_, qualified_name_to_id = kerbal_stable_names
 
     seq_templates = build_sequence_templates(kerbal_lpg)
 
     assert len(seq_templates) == 39
 
-    solid_booster_id = qualified_name_to_id[f"{ROCKET_BUILDING}Solid Booster <<PartDefinition>>"]
-    boosters_id = qualified_name_to_id[
+    _solid_booster_id = qualified_name_to_id[f"{ROCKET_BUILDING}Solid Booster <<PartDefinition>>"]
+    _boosters_id = qualified_name_to_id[
         f"{ROCKET_BUILDING}Solid Stage::boosters: Solid Booster <<PartUsage>>"
     ]
     liquid_stage_id = qualified_name_to_id[f"{ROCKET_BUILDING}Liquid Stage <<PartDefinition>>"]

--- a/tests/interpretation/test_playbook_phases.py
+++ b/tests/interpretation/test_playbook_phases.py
@@ -82,7 +82,7 @@ def test_phase_1_singleton_instances(kerbal_random_stage_1_complete, kerbal_stab
 
 @pytest.mark.skip("Need to refactor tests, after 0.19.0 upgrades")
 def test_phase_2_instance_creation(
-    kerbal_lpg, kerbal_random_stage_1_complete, kerbal_stable_names, kerbal_client
+    kerbal_lpg, kerbal_random_stage_1_complete, kerbal_stable_names
 ):
     *_, qualified_name_to_id = kerbal_stable_names
 

--- a/tests/interpretation/test_playbook_phases.py
+++ b/tests/interpretation/test_playbook_phases.py
@@ -16,7 +16,7 @@ PARTS_LIBRARY = "Model::Kerbal::Parts Library::"
 SIMPLE_MODEL = "Model::Simple Parts Model::"
 
 
-@pytest.mark.skip("Need to refactor tests, after 0.19.0 upgrades")
+@pytest.mark.skip("Need to refactor tests, after upgrades")
 def test_type_multiplicity_dict_building(kerbal_lpg, kerbal_stable_names):
     *_, qualified_name_to_id = kerbal_stable_names
 
@@ -44,7 +44,7 @@ def test_type_multiplicity_dict_building(kerbal_lpg, kerbal_stable_names):
     assert full_multiplicities[real_id] == 3038
 
 
-@pytest.mark.skip("Need to refactor tests, after 0.19.0 upgrades")
+@pytest.mark.skip("Need to refactor tests, after upgrades")
 def test_phase_1_instance_creation(kerbal_random_stage_1_instances, kerbal_stable_names):
     *_, qualified_name_to_id = kerbal_stable_names
 
@@ -62,7 +62,7 @@ def test_phase_1_instance_creation(kerbal_random_stage_1_instances, kerbal_stabl
     assert solid_booster_id not in kerbal_random_stage_1_instances
 
 
-@pytest.mark.skip("Need to refactor tests, after 0.19.0 upgrades")
+@pytest.mark.skip("Need to refactor tests, after upgrades")
 def test_phase_1_singleton_instances(kerbal_random_stage_1_complete, kerbal_stable_names):
     *_, qualified_name_to_id = kerbal_stable_names
 
@@ -80,7 +80,7 @@ def test_phase_1_singleton_instances(kerbal_random_stage_1_complete, kerbal_stab
     assert solid_booster_id not in kerbal_random_stage_1_complete
 
 
-@pytest.mark.skip("Need to refactor tests, after 0.19.0 upgrades")
+@pytest.mark.skip("Need to refactor tests, after upgrades")
 def test_phase_2_instance_creation(
     kerbal_lpg, kerbal_random_stage_1_complete, kerbal_stable_names
 ):
@@ -154,7 +154,7 @@ def test_phase_3_instance_sampling(kerbal_random_stage_3_complete, kerbal_stable
     assert len(kerbal_random_stage_3_complete[booster_empty_mass_id]) > 0
 
 
-@pytest.mark.skip("Need to refactor tests, after 0.19.0 upgrades")
+@pytest.mark.skip("Need to refactor tests, after upgrades")
 def test_phase_4_instance_sampling(
     kerbal_random_stage_4_complete, kerbal_stable_names, kerbal_lpg
 ):
@@ -208,7 +208,7 @@ def test_phase_4_instance_sampling(
     assert len(kerbal_random_stage_4_complete[booster_empty_mass_id]) > 0
 
 
-@pytest.mark.skip("Need to refactor tests, after 0.19.0 upgrades")
+@pytest.mark.skip("Need to refactor tests, after upgrades")
 def test_sp_phase_1_instance_creation(
     simple_parts_random_stage_1_instances, simple_parts_stable_names
 ):
@@ -229,7 +229,7 @@ def test_sp_phase_1_instance_creation(
     assert power_user_id not in simple_parts_random_stage_1_instances
 
 
-@pytest.mark.skip("Need to refactor tests, after 0.19.0 upgrades")
+@pytest.mark.skip("Need to refactor tests, after upgrades")
 def test_sp_phase_1_singleton_instances(
     simple_parts_random_stage_1_complete, simple_parts_stable_names
 ):
@@ -250,7 +250,7 @@ def test_sp_phase_1_singleton_instances(
     assert power_user_id not in simple_parts_random_stage_1_complete
 
 
-@pytest.mark.skip("Need to refactor tests, after 0.19.0 upgrades")
+@pytest.mark.skip("Need to refactor tests, after upgrades")
 def test_sp_phase_2_instance_creation(
     simple_parts_lpg,
     simple_parts_random_stage_1_complete,
@@ -284,7 +284,7 @@ def test_sp_phase_2_instance_creation(
     assert len(simple_parts_random_stage_1_complete[port_id]) == 6
 
 
-@pytest.mark.skip("Need to refactor tests, after 0.19.0 upgrades")
+@pytest.mark.skip("Need to refactor tests, after upgrades")
 def test_sp_phase_3_instance_sampling(
     simple_parts_random_stage_3_complete, simple_parts_stable_names
 ):

--- a/tests/jupyter/test_notebooks.py
+++ b/tests/jupyter/test_notebooks.py
@@ -2,7 +2,7 @@ import pytest
 from testbook import testbook
 
 
-@pytest.mark.skip("Need to refactor tests, after 0.19.0 upgrades")
+@pytest.mark.skip("Need to refactor tests, after upgrades")
 @testbook("docs/tutorials/01-Basic.ipynb", execute=True)
 def test_tutorial(tb):
     """Test the Tutorial notebook"""
@@ -16,7 +16,7 @@ def test_tutorial(tb):
     assert not set(m1_diagram.model.elements).symmetric_difference(set(tree.model.elements))
 
 
-@pytest.mark.skip("Need to refactor tests, after 0.19.0 upgrades")
+@pytest.mark.skip("Need to refactor tests, after upgrades")
 @testbook("tests/jupyter/notebooks/Playbook Explorer Parts Test.ipynb", execute=True)
 def test_simple_parts_explorer(tb):
     m0_interpretation = tb.ref("m0_interpretation")

--- a/tests/model/test_instantiation.py
+++ b/tests/model/test_instantiation.py
@@ -1,7 +1,6 @@
 import pytest
 
 from pymbe.model import VALUE_METATYPES, ValueHolder
-from tests.conftest import kerbal_model
 
 
 @pytest.mark.skip("Need to refactor tests, after 0.19.0 upgrades")

--- a/tests/model/test_instantiation.py
+++ b/tests/model/test_instantiation.py
@@ -3,7 +3,7 @@ import pytest
 from pymbe.model import VALUE_METATYPES, ValueHolder
 
 
-@pytest.mark.skip("Need to refactor tests, after 0.19.0 upgrades")
+@pytest.mark.skip("Need to refactor tests, after upgrades")
 def test_instantiation(kerbal_model):
     model = kerbal_model
 

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1,4 +1,3 @@
-import warnings
 from pathlib import Path
 from uuid import uuid4
 

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1,6 +1,10 @@
-from copy import deepcopy
+import warnings
+from pathlib import Path
+from uuid import uuid4
 
-from tests.conftest import all_models, kerbal_model
+import pytest
+
+from pymbe.model import Element, Model
 
 
 def test_respect_of_sysml(all_models):
@@ -24,7 +28,7 @@ def test_kerbal_model(kerbal_model):
     kerbal = model.ownedElement["Kerbal"]
 
     assert kerbal.name == "Kerbal", f"Element name should be 'Kerbal', not '{kerbal.name}'"
-    assert kerbal == kerbal._id, f"Element should equate to its id"
+    assert kerbal == kerbal._id, "Element should equate to its id"
 
     my_rocket = kerbal(name="My Rocket")
     assert (
@@ -44,15 +48,83 @@ def test_kerbal_model(kerbal_model):
 def test_relationships(kerbal_model):
     model = kerbal_model
 
+    rocket_part = None
     for element in model.elements.values():
         if element.name == "Kerbal Rocket Part":
             rocket_part = element
+            break
 
+    subclass = None
     for subclass in rocket_part.reverseSuperclassing:
         if subclass.name == "Parachute":
             break
 
+    assert subclass, "Did not find the `Parachute`"
+    assert rocket_part, "Did not find the `Kerbal Rocket Part`"
     assert subclass.throughSuperclassing[0].name == rocket_part.name
+
+
+def test_edge_cases():
+    name = f"model_{uuid4()}"
+    filename = f"{name}.json"
+    model = Model(elements={}, name=name)
+    cwd = Path(".")
+
+    with pytest.warns(UserWarning):
+        model.save_to_file()
+    assert not list(cwd.glob(filename)), f"Model should NOT have been saved! {list(cwd.glob('*'))}"
+
+    empty_element = Element(_data={}, _model=model)
+    assert empty_element._is_proxy, "Element should be marked as proxy!"
+
+    model.save_to_file()
+    saved_file = list(cwd.glob(filename))
+    assert saved_file, "Model should have been saved with .json extension added!"
+
+    with pytest.warns(UserWarning):
+        model.save_to_file(filename)
+    saved_file[0].unlink()
+
+
+def test_package_references(kerbal_model):
+    model = kerbal_model
+    packages = model.packages
+
+    assert packages, "Kerbal should have some packages!"
+
+    a_package, sub_package = None, None
+    for a_package in packages:
+        sub_packages = [
+            pkg
+            for pkg in a_package.ownedElement
+            if pkg._metatype == "Package" and pkg.ownedElement
+        ]
+        if sub_packages:
+            sub_package = sub_packages[0]
+            break
+
+    assert a_package, "Kerbal model should have a package that has another package"
+    assert sub_package, "Kerbal model should have a nested package"
+
+    owned_element = sub_package.ownedElement[0]
+    assert sub_package.ownedElement[owned_element.name] == owned_element
+
+    assert (
+        owned_element.owning_package == sub_package
+    ), f"{owned_element} should know it is owned by {sub_package}"
+    assert owned_element.is_in_package(a_package), f"{owned_element} should be in {a_package}"
+    assert owned_element.is_in_package(sub_package), f"{owned_element} should be in {sub_package}"
+    assert not a_package.is_in_package(
+        owned_element
+    ), f"{a_package} should NOT be owned by {owned_element}"
+    assert not a_package.is_in_package(
+        sub_package
+    ), f"{a_package} should NOT be owned by {sub_package}"
+    assert not sub_package.is_in_package(
+        owned_element
+    ), f"{sub_package} should NOT be owned by {owned_element}"
+
+    assert (a_package > sub_package) == (a_package.name > sub_package.name)
 
 
 def test_accessors(kerbal_model):

--- a/tests/query/test_feature_queries.py
+++ b/tests/query/test_feature_queries.py
@@ -9,14 +9,13 @@ from pymbe.query.query import (
     roll_up_multiplicity_for_type,
     roll_up_upper_multiplicity,
 )
-from tests.conftest import kerbal_model_loaded_client
 
 ROCKET_BUILDING = "Model::Kerbal::Rocket Building::"
 PARTS_LIBRARY = "Model::Kerbal::Parts Library::"
 SIMPLE_MODEL = "Model::Simple Parts Model::"
 
 
-def test_feature_to_type1(kerbal_client, kerbal_lpg, kerbal_stable_names):
+def test_feature_to_type1(kerbal_lpg, kerbal_stable_names):
     *_, qualified_name_to_id = kerbal_stable_names
 
     engines_feat = qualified_name_to_id[
@@ -27,7 +26,7 @@ def test_feature_to_type1(kerbal_client, kerbal_lpg, kerbal_stable_names):
     assert get_types_for_feature(kerbal_lpg, engines_feat) == [engine_type_feat]
 
 
-def test_type_to_feature1(kerbal_client, kerbal_lpg, kerbal_stable_names):
+def test_type_to_feature1(kerbal_lpg, kerbal_stable_names):
     *_, qualified_name_to_id = kerbal_stable_names
 
     engines_feat = qualified_name_to_id[

--- a/tests/query/test_feature_queries.py
+++ b/tests/query/test_feature_queries.py
@@ -37,7 +37,7 @@ def test_type_to_feature1(kerbal_lpg, kerbal_stable_names):
     assert get_features_typed_by_type(kerbal_lpg, engine_type_feat) == [engines_feat]
 
 
-@pytest.mark.skip("Need to refactor tests, after 0.19.0 upgrades")
+@pytest.mark.skip("Need to refactor tests, after upgrades")
 def test_type_to_feature2(simple_parts_client, simple_parts_lpg, simple_parts_stable_names):
     *_, qualified_name_to_id = simple_parts_stable_names
 
@@ -196,7 +196,7 @@ def test_type_multiplicity_rollup1(kerbal_lpg, kerbal_stable_names):
     assert rocket_upper == 0
 
 
-@pytest.mark.skip("Need to refactor tests, after 0.19.0 upgrades")
+@pytest.mark.skip("Need to refactor tests, after upgrades")
 def test_type_multiplicity_rollup2(simple_parts_lpg, simple_parts_stable_names):
     *_, qualified_name_to_id = simple_parts_stable_names
 


### PR DESCRIPTION
# Changes
* Circuit Builder
  * Started to add `openmdao` functionality to the `Circuit Permutations` notebook
  * Added the `Circuit Builder` model to the `fixtures`
* Added element proxy capability, i.e., ability to download a non-dereferenced element from the API client
  * Need to do more work to make this work in the UI
* Minor fixes to the `lru_cache` of URLs in the `APIClient`, and added a method to clear it
* Brought in fixes from Bjorn for the `random_generator_playbook_phase_5` function, and refactored and cleaned it up a bit
* Added more tests for the functionality in `Element` and `Model`
* Refactored API Clients and `FileLoader`
* Started cleaning up and refactoring `conftest.py` and did some minor cleanup in the other tests